### PR TITLE
Upgrade to Terraform 0.12 syntax

### DIFF
--- a/terraform/groups/lambda/main.tf
+++ b/terraform/groups/lambda/main.tf
@@ -32,20 +32,20 @@ locals {
 }
 
 module "lambda" {
-  source               = "./module-lambda"
-  service              = var.service
-  handler              = var.handler
-  memory_megabytes     = var.memory_megabytes
-  runtime              = var.runtime
-  timeout_seconds      = var.timeout_seconds
-  release_version      = var.release_version
-  release_bucket_name  = var.release_bucket_name
-  execution_role       = module.lambda-roles.execution_role
+  source                            = "./module-lambda"
+  service                           = var.service
+  handler                           = var.handler
+  memory_megabytes                  = var.memory_megabytes
+  runtime                           = var.runtime
+  timeout_seconds                   = var.timeout_seconds
+  release_version                   = var.release_version
+  release_bucket_name               = var.release_bucket_name
+  execution_role                    = module.lambda-roles.execution_role
   open_lambda_environment_variables = var.open_lambda_environment_variables
-  aws_profile          = var.aws_profile
-  subnet_ids           = local.test_and_development_subnet_ids
-  security_group_ids   = [module.security-group.lambda_into_vpc_id]
-  environment          = var.environment
+  aws_profile                       = var.aws_profile
+  subnet_ids                        = local.test_and_development_subnet_ids
+  security_group_ids                = [module.security-group.lambda_into_vpc_id]
+  environment                       = var.environment
 }
 
 module "lambda-roles" {

--- a/terraform/groups/lambda/module-cloud-watch/main.tf
+++ b/terraform/groups/lambda/module-cloud-watch/main.tf
@@ -1,19 +1,19 @@
 resource "aws_cloudwatch_event_rule" "lfp_error_reporter" {
-  name        = "${var.service}-${var.environment}"
-  description = "Call lfp error reporter lambda"
-  schedule_expression =var.cron_schedule
+  name                = "${var.service}-${var.environment}"
+  description         = "Call lfp error reporter lambda"
+  schedule_expression = var.cron_schedule
 }
 
 resource "aws_cloudwatch_event_target" "call_lfp_error_reporter_lambda" {
-    rule = aws_cloudwatch_event_rule.lfp_error_reporter.name
-    target_id = "${var.service}-${var.environment}"
-    arn = var.lambda_arn
+  rule      = aws_cloudwatch_event_rule.lfp_error_reporter.name
+  target_id = "${var.service}-${var.environment}"
+  arn       = var.lambda_arn
 }
 
 resource "aws_lambda_permission" "allow_cloudwatch_to_call_lfp_error_reporter" {
-    statement_id = "AllowLambdaExecutionFromCloudWatch"
-    action = "lambda:InvokeFunction"
-    function_name = "${var.service}-${var.environment}"
-    principal = "events.amazonaws.com"
-    source_arn = aws_cloudwatch_event_rule.lfp_error_reporter.arn
+  statement_id  = "AllowLambdaExecutionFromCloudWatch"
+  action        = "lambda:InvokeFunction"
+  function_name = "${var.service}-${var.environment}"
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.lfp_error_reporter.arn
 }

--- a/terraform/groups/lambda/module-cloud-watch/variables.tf
+++ b/terraform/groups/lambda/module-cloud-watch/variables.tf
@@ -1,5 +1,5 @@
 variable service {
-  type        = string
+  type = string
 }
 
 variable lambda_arn {
@@ -8,9 +8,9 @@ variable lambda_arn {
 }
 
 variable environment {
-  type        = string
+  type = string
 }
 
 variable cron_schedule {
-  type        = string
+  type = string
 }

--- a/terraform/groups/lambda/module-lambda-roles/main.tf
+++ b/terraform/groups/lambda/module-lambda-roles/main.tf
@@ -79,7 +79,7 @@ data "aws_iam_policy_document" "lfp_error_reporter_execution" {
 # ------------------------------------------------------------------------------
 resource "aws_iam_role" "lfp_error_reporter_execution" {
   name               = "${var.service}-execution-${var.environment}"
-  assume_role_policy = "${data.aws_iam_policy_document.lfp_error_reporter_trust.json}"
+  assume_role_policy = data.aws_iam_policy_document.lfp_error_reporter_trust.json
 }
 
 # ------------------------------------------------------------------------------

--- a/terraform/groups/lambda/module-lambda-roles/variables.tf
+++ b/terraform/groups/lambda/module-lambda-roles/variables.tf
@@ -1,7 +1,7 @@
 variable service {
-  type        = string
+  type = string
 }
 
 variable environment {
-  type        = string
+  type = string
 }

--- a/terraform/groups/lambda/module-lambda/main.tf
+++ b/terraform/groups/lambda/module-lambda/main.tf
@@ -14,13 +14,13 @@ resource "aws_lambda_function" "lfp_error_reporter" {
   memory_size   = var.memory_megabytes
   timeout       = var.timeout_seconds
   runtime       = var.runtime
-  
+
   vpc_config {
     subnet_ids         = var.subnet_ids
     security_group_ids = var.security_group_ids
   }
   environment {
-    variables = merge (
+    variables = merge(
       data.vault_generic_secret.lambda_environment_variables.data,
       var.open_lambda_environment_variables
     )

--- a/terraform/groups/lambda/module-lambda/variables.tf
+++ b/terraform/groups/lambda/module-lambda/variables.tf
@@ -1,33 +1,33 @@
 variable handler {
-  type        = string
+  type = string
 }
 
 variable memory_megabytes {
-  type        = string
+  type = string
 }
 
 variable release_bucket_name {
-  type        = string
+  type = string
 }
 
 variable runtime {
-  type        = string
+  type = string
 }
 
 variable timeout_seconds {
-  type        = string
+  type = string
 }
 
 variable service {
-  type        = string
+  type = string
 }
 
 variable release_version {
-  type        = string
+  type = string
 }
 
 variable open_lambda_environment_variables {
-  type        = map(string)
+  type = map(string)
 }
 
 variable execution_role {
@@ -46,9 +46,9 @@ variable security_group_ids {
 }
 
 variable environment {
-  type        = string
+  type = string
 }
 
 variable aws_profile {
-  type        = string
+  type = string
 }

--- a/terraform/groups/lambda/module-security-group/main.tf
+++ b/terraform/groups/lambda/module-security-group/main.tf
@@ -1,13 +1,13 @@
 resource "aws_security_group" "lfp_error_reporter" {
   name        = "${var.environment}-${var.service}-lambda-into-vpc"
   description = "Outbound rules for payment error reporter lambda"
-  vpc_id = var.vpc_id
+  vpc_id      = var.vpc_id
 
   egress {
-    from_port       = 0
-    to_port         = 0
-    protocol        = "-1"
-    cidr_blocks     = ["0.0.0.0/0"]
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
   }
 }
 

--- a/terraform/groups/lambda/module-security-group/variables.tf
+++ b/terraform/groups/lambda/module-security-group/variables.tf
@@ -1,11 +1,11 @@
 variable "vpc_id" {
-  type        = string
+  type = string
 }
 
 variable "environment" {
-  type        = string
+  type = string
 }
 
 variable "service" {
-  type        = string
+  type = string
 }


### PR DESCRIPTION
These changes reformat the Terraform source files and remove deprecated interpolation-only expressions, in line with Terraform 0.12 syntax and best practice.