### PR TITLE
Update dates and times for which lambda data generated.

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -10,8 +10,11 @@ import (
 	"github.com/companieshouse/lfp-error-reporter/models"
 )
 
-const lfpFileNamePrefix = "CHS-LFP-CARD-ERRORS-"
-const csvFileSuffix = ".csv"
+const (
+	lfpFileNamePrefix string = "CHS-LFP-CARD-ERRORS-"
+	csvFileSuffix     string = ".csv"
+	YYYYMMDD          string = "2006-01-02"
+)
 
 // Service provides functionality by which to fetch lfp error CSV's
 type Service interface {
@@ -72,6 +75,6 @@ func constructCSV(data models.CSVable, fileNamePrefix string, reconciliationMeta
 
 	return models.CSV{
 		Data:     data,
-		FileName: fileNamePrefix + reconciliationMetaData.ReconciliationDate + csvFileSuffix,
+		FileName: fileNamePrefix + reconciliationMetaData.StartTime.AddDate(0, 0, -1).Format(YYYYMMDD) + csvFileSuffix,
 	}
 }

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/companieshouse/lfp-error-reporter/config"
 	"github.com/companieshouse/lfp-error-reporter/dao"
@@ -11,9 +12,12 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
-const expectedTLFPFileNamePrefix string = "CHS-LFP-CARD-ERRORS-"
-const expectedCSVFileSuffix = ".csv"
-const reconciliationDate string = "2019-01-01"
+const (
+	expectedTLFPFileNamePrefix string = "CHS-LFP-CARD-ERRORS-"
+	expectedCSVFileSuffix      string = ".csv"
+	reconciliationDate         string = "2019-01-01"
+	timeFormatLayout           string = "2006-01-02"
+)
 
 func createMockService(cfg *config.Config, mockDao *dao.MockDAO) *ServiceImpl {
 
@@ -28,9 +32,12 @@ func TestUnitGetLFPCSV(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
+	startTime, _ := time.Parse(timeFormatLayout, reconciliationDate)
+
 	cfg := config.Config{}
 	reconciliationMetaData := models.ReconciliationMetaData{
 		ReconciliationDate: reconciliationDate,
+		StartTime:          startTime,
 	}
 
 	Convey("Subject: Success", t, func() {
@@ -52,7 +59,7 @@ func TestUnitGetLFPCSV(t *testing.T) {
 				Convey("And a CSV is successfully constructed", func() {
 
 					So(lfpsCSV, ShouldNotBeNil)
-					So(lfpsCSV.FileName, ShouldEqual, expectedTLFPFileNamePrefix+reconciliationMetaData.ReconciliationDate+expectedCSVFileSuffix)
+					So(lfpsCSV.FileName, ShouldEqual, expectedTLFPFileNamePrefix+reconciliationMetaData.StartTime.AddDate(0, 0, -1).Format(timeFormatLayout)+expectedCSVFileSuffix)
 				})
 			})
 		})


### PR DESCRIPTION
It transpires that the `lfp-error-reporter` lambda was attempting to pull data from MongoDB using date on which was invoked rather than the day before.

Since it's invoked at 1am each morning, its either not finding any data or minimal data! This PR addresses that issue with using the previous date as the date in the date range used to pull data from MongoDB. Test updated to reflect.