### PR TITLE
feat: cronjob updated as using incorrect format

### DIFF
--- a/terraform/groups/lambda/profiles/development-eu-west-2/cidev/vars
+++ b/terraform/groups/lambda/profiles/development-eu-west-2/cidev/vars
@@ -4,7 +4,7 @@
 
 environment = "cidev"
 aws_profile = "development-eu-west-2"
-cron_schedule = "cron(15,45 * * * *)"
+cron_schedule = "cron(0/30 * ? * * *)"
 aws_region = "eu-west-2"
 release_bucket_name = "development-eu-west-2.release.ch.gov.uk"
 remote_state_bucket = "ch-development-terraform-state-london"


### PR DESCRIPTION
  Required to test a security update hasn't caused a fault with the
  execution. Will revert once tested.

SEC-35